### PR TITLE
feat(dmaas): test adding cloud provider credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mayadata-io/kubera-api-testing
 
 go 1.12
 
-require github.com/go-resty/resty/v2 v2.3.0
+require (
+	github.com/go-resty/resty/v2 v2.3.0
+	github.com/tidwall/gjson v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
 github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
+github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
+github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
+github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=

--- a/kubera/authentication/authentication.go
+++ b/kubera/authentication/authentication.go
@@ -8,6 +8,7 @@ import (
 	conn "github.com/mayadata-io/kubera-api-testing/kubera/connection"
 )
 
+// Token struct of JWT token and AccountID
 type Token struct {
 	JWT       string `json:"jwt"`
 	AccountID string `json:"accountId"`
@@ -25,6 +26,7 @@ func (t Token) String() string {
 	return string(raw)
 }
 
+// APIError struct of error, error message, status code and status
 type APIError struct {
 	Err        error  `json:"err"`
 	Message    string `json:"message"`
@@ -44,9 +46,12 @@ func (e *APIError) Error() string {
 	return string(raw)
 }
 
+// KuberaError represent error message
 type KuberaError struct {
 	Message string `json:"message"`
 }
+
+// TokenFetching struct of token fetching connection
 type TokenFetching struct {
 	conn.Connection `json:"connection"`
 }
@@ -66,6 +71,7 @@ func (t TokenFetching) String() string {
 	return string(raw)
 }
 
+// TokenFetchingConfig is struct of connection
 type TokenFetchingConfig struct {
 	Connection conn.Connection
 }
@@ -78,13 +84,12 @@ func NewTokenFetcher(config TokenFetchingConfig) *TokenFetching {
 }
 
 // Fetch returns authenticated token
-func (f *TokenFetching) Fetch() (Token, error) {
+func (t *TokenFetching) Fetch() (Token, error) {
 	client := resty.New()
-	url := f.HostName + "v3/token"
 	token := Token{}
 	kErr := KuberaError{}
 	bodyData := map[string]interface{}{
-		"code":         fmt.Sprintf("%s:%s", f.UserName, f.Password),
+		"code":         fmt.Sprintf("%s:%s", t.UserName, t.Password),
 		"authProvider": "localAuthConfig",
 	}
 	resp, err := client.R().
@@ -96,7 +101,12 @@ func (f *TokenFetching) Fetch() (Token, error) {
 		//SetResult automatic unmarshalling for the request,
 		// if response status code is between 200 and 299
 		SetResult(&token).
-		Post(url)
+		Post(
+			fmt.Sprintf(
+				"%s/v3/token",
+				t.HostName,
+			),
+		)
 
 	if err != nil || kErr.Message != "" || !resp.IsSuccess() {
 		return Token{}, &APIError{

--- a/kubera/connection/connection.go
+++ b/kubera/connection/connection.go
@@ -12,7 +12,7 @@ const (
 	kuberaPass = "KUBERA_PASS" //Kubera password
 )
 
-// Connection defines the structure of userCerdentials
+// Connection defines the structure of userCredentials
 type Connection struct {
 	HostName string
 	UserName string
@@ -52,5 +52,22 @@ func Get() Connection {
 		}
 	})
 	return connection
+
+}
+
+// GetHostName return the  kubera host(URL)
+func GetHostName() string {
+
+	if connection.HostName != "" {
+		return connection.HostName
+	}
+	var once sync.Once
+
+	once.Do(func() {
+		connection = Connection{
+			HostName: os.Getenv(kuberaHost),
+		}
+	})
+	return connection.HostName
 
 }

--- a/kubera/dmaas/credentials/add_credential.go
+++ b/kubera/dmaas/credentials/add_credential.go
@@ -1,0 +1,203 @@
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/mayadata-io/kubera-api-testing/kubera/authentication"
+	"github.com/mayadata-io/kubera-api-testing/kubera/connection"
+	"github.com/tidwall/gjson"
+)
+
+// CloudCredential contains all parameters which should be passed to add cloud credential
+type CloudCredential struct {
+	Name       string   `json:"name"`
+	ProjectID  string   `json:"projectId"`
+	ProviderID string   `json:"providerId"`
+	Cred       CredType `json:"credential"`
+}
+
+// CredType is cloud provider access id and secret key
+type CredType struct {
+	AccessID  string `json:"access_id"`
+	SecretKey string `json:"secret_key"`
+}
+
+// CredentialAdding represent the fields required to add a credential
+type CredentialAdding struct {
+	CloudName string
+	CredName  string
+	Username  string
+	Password  string
+
+	jwtToken   string
+	hostName   string
+	groupID    string
+	projectID  string
+	providerID string
+}
+
+// NewCredentialsAdder return fields value required to add a credential
+func NewCredentialsAdder(cred CredentialAdding) *CredentialAdding {
+	return &CredentialAdding{
+		CloudName: cred.CloudName,
+		CredName:  cred.CredName,
+		Username:  cred.Username,
+		Password:  cred.Password,
+	}
+}
+
+// SetKuberaDetails sets JWT token and Kubera url
+func (a *CredentialAdding) SetKuberaDetails() error {
+	conn := connection.Get()
+	fetcher := authentication.NewTokenFetcher(
+		authentication.TokenFetchingConfig{
+			Connection: conn,
+		})
+	tkn, err := fetcher.Fetch()
+	if err != nil {
+		return err
+	}
+	// setting JWT token and Kubera hostname
+	a.jwtToken = tkn.JWT
+	a.hostName = connection.GetHostName()
+	return nil
+}
+
+// FetchGroupProjectID method sets group and project ID
+func (a *CredentialAdding) FetchGroupProjectID() error {
+	client := resty.New()
+	kErr := authentication.KuberaError{}
+	resp, err := client.R().
+		SetHeader("Accept", "application/json").
+		SetHeader("Cookie",
+			fmt.Sprintf(
+				"token=%s;authProvider=localAuthConfig",
+				a.jwtToken,
+			),
+		).
+		SetError(&kErr).
+		Get(
+			fmt.Sprintf(
+				"%s/v3/groups",
+				a.hostName,
+			),
+		)
+
+	if err != nil || kErr.Message != "" || !resp.IsSuccess() {
+		return &authentication.APIError{
+			Err:        err,
+			Message:    kErr.Message,
+			StatusCode: resp.StatusCode(),
+			Status:     resp.Status(),
+		}
+	}
+	// groupIDPath denotes the path of group id by using ProjectAccount as filter.
+	groupIDPath := fmt.Sprintf("data.#(name==%s).id", "ProjectAccount")
+	// projectIDPath denotes the path of project id by using ProjectAccount as filter.
+	projectIDPath := fmt.Sprintf("data.#(name==%s).projectId", "ProjectAccount")
+
+	// set group ID and project ID
+	a.groupID = gjson.GetBytes(resp.Body(), groupIDPath).String()
+	a.projectID = gjson.GetBytes(resp.Body(), projectIDPath).String()
+
+	return nil
+}
+
+// FetchBackupProviderID method sets backup provider ID
+func (a *CredentialAdding) FetchBackupProviderID() error {
+	client := resty.New()
+	kErr := authentication.KuberaError{}
+	resp, err := client.R().
+		SetHeader("Accept", "application/json").
+		SetHeader("Cookie",
+			fmt.Sprintf(
+				"token=%s;authProvider=localAuthConfig",
+				a.jwtToken,
+			),
+		).
+		SetError(&kErr).
+		Get(
+			fmt.Sprintf("%s/v3/backupproviders",
+				a.hostName,
+			),
+		)
+	if err != nil || kErr.Message != "" || !resp.IsSuccess() {
+		return &authentication.APIError{
+			Err:        err,
+			Message:    kErr.Message,
+			StatusCode: resp.StatusCode(),
+			Status:     resp.Status(),
+		}
+	}
+	// path of backup provider id by using name as filter.
+	providerIDPath := fmt.Sprintf("data.#(name==%s).id", a.CloudName)
+	// set backup provider id
+	a.providerID = gjson.GetBytes(resp.Body(), providerIDPath).String()
+	return nil
+}
+
+// AddCredential method will add cloud provider credential
+func (a *CredentialAdding) AddCredential() error {
+	client := resty.New()
+	kErr := authentication.KuberaError{}
+	// body of POST request
+	body := CloudCredential{
+		Name:       a.CredName,
+		ProjectID:  a.projectID,
+		ProviderID: a.providerID,
+		Cred: CredType{
+			AccessID:  a.Username,
+			SecretKey: a.Password,
+		},
+	}
+	// body of POST request in JSON format
+	bodyRaw, err := json.Marshal(body)
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(bodyRaw).
+		SetHeader("Cookie",
+			fmt.Sprintf(
+				"token=%s;authProvider=localAuthConfig",
+				a.jwtToken,
+			),
+		).
+		//SetError method automatic unmarshalling if response status code >= 399
+		// and content type either JSON or XML.
+		SetError(&kErr).
+		Post(
+			fmt.Sprintf(
+				"%s/v3/groups/%s/providercredentials",
+				connection.GetHostName(),
+				a.groupID,
+			),
+		)
+
+	if err != nil || kErr.Message != "" || !resp.IsSuccess() {
+		return &authentication.APIError{
+			Err:        err,
+			Message:    kErr.Message,
+			StatusCode: resp.StatusCode(),
+			Status:     resp.Status(),
+		}
+	}
+	return nil
+}
+
+// AddCloudCredential method add backup providers credential
+func (a *CredentialAdding) AddCloudCredential() error {
+	fns := []func() error{
+		a.SetKuberaDetails,
+		a.FetchGroupProjectID,
+		a.FetchBackupProviderID,
+		a.AddCredential,
+	}
+	for _, fn := range fns {
+		err := fn()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kubera/dmaas/credentials/add_credential_test.go
+++ b/kubera/dmaas/credentials/add_credential_test.go
@@ -1,0 +1,186 @@
+package credentials
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCredentialAddition(t *testing.T) {
+
+	var (
+		awsAccessID       = os.Getenv("AWS_ACCESS_ID")
+		awsSecretKey      = os.Getenv("AWS_SECRET_KEY")
+		cloudianAccessID  = os.Getenv("CLOUDIAN_ACCESS_ID")
+		cloudianSecretKey = os.Getenv("CLOUDIAN_SECRET_KEY")
+		minioAccessID     = os.Getenv("MINIO_ACCESS_ID")
+		minioSecretKey    = os.Getenv("MINIO_SECRET_KEY")
+	)
+
+	var tests = map[string]struct {
+		CloudProvider string
+		Name          string
+		AccessID      string
+		SecretKey     string
+		IsError       bool
+	}{
+		"aws bucket with all details": {
+			CloudProvider: "aws",
+			Name:          "aws-dmaas-test",
+			AccessID:      awsAccessID,
+			SecretKey:     awsSecretKey,
+		},
+		"aws bucket with duplicate name": {
+			CloudProvider: "aws",
+			Name:          "aws-dmaas-test",
+			AccessID:      awsAccessID,
+			SecretKey:     awsSecretKey,
+		},
+		"aws bucket with name length less than 6 character": {
+			CloudProvider: "aws",
+			Name:          "awsdm",
+			AccessID:      awsAccessID,
+			SecretKey:     awsSecretKey,
+		},
+		"aws bucket with name length more than 25 character": {
+			CloudProvider: "aws",
+			Name:          "aws-dmaas-test-backup-restore-cred",
+			AccessID:      awsAccessID,
+			SecretKey:     awsSecretKey,
+		},
+		"aws bucket without name": {
+			CloudProvider: "aws",
+			AccessID:      awsAccessID,
+			SecretKey:     awsSecretKey,
+			IsError:       true,
+		},
+		"aws bucket without accessID ": {
+			CloudProvider: "aws",
+			Name:          "aws-cred-neg",
+			SecretKey:     awsSecretKey,
+			IsError:       true,
+		},
+		"aws bucket without secretKey": {
+			CloudProvider: "aws",
+			Name:          "aws-cred-neg",
+			AccessID:      awsAccessID,
+			IsError:       true,
+		},
+		"aws bucket without name, accessID & secretKey": {
+			CloudProvider: "aws",
+			IsError:       true,
+		},
+		"cloudian bucket with all details": {
+			CloudProvider: "cloudian",
+			Name:          "cloudian-dmaas-test",
+			AccessID:      cloudianAccessID,
+			SecretKey:     cloudianSecretKey,
+		},
+		"cloudian bucket with duplicate name": {
+			CloudProvider: "cloudian",
+			Name:          "cloudian-dmaas-test",
+			AccessID:      cloudianAccessID,
+			SecretKey:     cloudianSecretKey,
+		},
+		"cloudian bucket with name length less than 6 character": {
+			CloudProvider: "cloudian",
+			Name:          "cldm",
+			AccessID:      cloudianAccessID,
+			SecretKey:     cloudianSecretKey,
+		},
+		"cloudian bucket with name length more than 25 character": {
+			CloudProvider: "cloudian",
+			Name:          "cloudian-dmaas-test-backup-restore-cred",
+			AccessID:      cloudianAccessID,
+			SecretKey:     cloudianSecretKey,
+		},
+		"cloudian bucket without name": {
+			CloudProvider: "cloudian",
+			AccessID:      cloudianAccessID,
+			SecretKey:     cloudianSecretKey,
+			IsError:       true,
+		},
+		"cloudian bucket without accessID": {
+			CloudProvider: "cloudian",
+			Name:          "cloudian-cred-neg",
+			SecretKey:     cloudianSecretKey,
+			IsError:       true,
+		},
+		"cloudian bucket without secretKey": {
+			CloudProvider: "cloudian",
+			Name:          "cloudian-cred-neg",
+			AccessID:      cloudianAccessID,
+			IsError:       true,
+		},
+		"cloudian bucket without name, accessID & secretKey": {
+			CloudProvider: "cloudian",
+			IsError:       true,
+		},
+		"minio bucket with all details": {
+			CloudProvider: "minio",
+			Name:          "minio-dmaas-test",
+			AccessID:      minioAccessID,
+			SecretKey:     minioSecretKey,
+		},
+		"minio bucket with duplicate name": {
+			CloudProvider: "minio",
+			Name:          "minio-dmaas-test",
+			AccessID:      minioAccessID,
+			SecretKey:     minioSecretKey,
+		},
+		"minio bucket with name length less than 6 character": {
+			CloudProvider: "minio",
+			Name:          "minio",
+			AccessID:      minioAccessID,
+			SecretKey:     minioSecretKey,
+		},
+		"minio bucket with name length more than 25 character": {
+			CloudProvider: "minio",
+			Name:          "minio-dmaas-test-backup-restore-cred",
+			AccessID:      minioAccessID,
+			SecretKey:     minioSecretKey,
+		},
+		"minio bucket without name": {
+			CloudProvider: "minio",
+			AccessID:      minioAccessID,
+			SecretKey:     minioSecretKey,
+			IsError:       true,
+		},
+		"minio bucket without accessID": {
+			CloudProvider: "minio",
+			Name:          "minio-cred-neg",
+			SecretKey:     minioSecretKey,
+			IsError:       true,
+		},
+		"minio bucket without secretKey": {
+			CloudProvider: "minio",
+			Name:          "minio-cred-neg",
+			AccessID:      minioAccessID,
+			IsError:       true,
+		},
+		"minio bucket without name, accessID & secretKey": {
+			CloudProvider: "minio",
+			IsError:       true,
+		},
+	}
+	for name, mock := range tests {
+		name := name // Pin it
+		mock := mock // Pin it
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cred := NewCredentialsAdder(CredentialAdding{
+				CloudName: mock.CloudProvider,
+				CredName:  mock.Name,
+				Username:  mock.AccessID,
+				Password:  mock.SecretKey,
+			})
+			err := cred.AddCloudCredential()
+			if !mock.IsError && err != nil {
+				t.Fatalf("Failed to add cloud credential with error \nerror=%s ",
+					err)
+			}
+			if mock.IsError && err == nil {
+				t.Fatalf("Expected error got none: \nerror=%s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Test Description
Test adding cloud provider credentials. This is used by Kubera to authenticate to cloud provider bucket during DMaaS backup and restore operation.

#### Endpoints Invoked
Group ID:` https://<Kubera_Host>t>/v3/groups`
Project ID:` https://<Kubera_Host>t>/v3/groups`
Backup provider ID:` https://<Kubera_Host>t>/v3/backupproviders`
Provider credentials:` https://<Kubera_Host>t>/v3/groups/<groupID>/providercredentials`

#### Body :
``` json
{
    "name": "<credential_title>",
    "projectId": "<project_id>",
    "providerId": "<backup_provider_id>"
    "credential": {
        "access_id": "<backup_provider_username>",
        "secret_key": "<backup_provider_password>"
    }
}
```
#### Folder Structure
```
|_ kubera-api-testing/
    |__ kubera/
    |   |__ connection/
    |   |    |__ connection.go
    |   |__ authentication/
    |   |     |__ authentication_test.go
    |   |     |__ authentication.go
    |   |__ dmaas
    |          |__ credentials
    |               |__ add_credential.go
    |               |__ add-credential_test.go
    |__ go.mod
    |__ go.sum
    |__ makefile
```
### How to run the test : 
 -  Kubera credentials , Kubera host, cloud provider credential need to set as environment variables
```console
KUBERA_HOST="<Kubera_URL>" 
KUBERA_USER="<kubera_user_name>" 
KUBERA_PASS="<kubera_user_password>" 
MINIO_ACCESS_ID="<minio_access_id>"
MINIO_SECRET_KEY="<minio_access_key>"
AWS_ACCESS_ID="<aws_access_id>"
AWS_SECRET_KEY="<aws_access_key>"
CLOUDIAN_ACCESS_ID="<cloudian_access_id>"
CLOUDIAN_SECRET_KEY="<cloudian_access_key>"
```
- Run test
 ```console
go test ./... 
```
Expected output in case of test failure 

```
=== CONT  TestCredentialAddition/cloudian_bucket_with_name_length_less_than_6_character
    add_credential_test.go:178: Failed to add cloud credential with error 
        error={
         ."err": null,
         ."message": "",
         ."statusCode": 422,
         ."status": "422 Unprocessable Entity"
         } 
=== CONT  TestCredentialAddition/minio_bucket_without_name
=== CONT  TestCredentialAddition/cloudian_bucket_with_name_length_more_than_25_character
    add_credential_test.go:178: Failed to add cloud credential with error 
        error={
         ."err": null,
         ."message": "",
         ."statusCode": 422,
         ."status": "422 Unprocessable Entity"
         } 
```
Signed-off-by: Rohan Kumar <rohan.kumar@mayadata.io>